### PR TITLE
Fixes typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Run `clipshare 11337` on another machine of your network
 
 And then on another machine on the same network
 ```bash
-$ clipshare 113377
-Connecting to clipboard 113377...
+$ clipshare 11337
+Connecting to clipboard 11337...
 Clipboards connected
 ```
 


### PR DESCRIPTION
Reading the docs I noticed the code shown for the server side example is 11337, but the code displayed on the client side instructions is 113377, which has an extra "7" at the end. I believe that is a typo and both codes should be the same.